### PR TITLE
feat: add "theme" to blocks definition

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -73,16 +73,37 @@ $aModule = [
 	],
 	'blocks'      => [
 		[
+			'theme'    => 'flow',
 			'template' => 'layout/base.tpl',
 			'block'    => 'base_js',
 			'file'     => '/Application/views/blocks/base_js.tpl'
 		],
 		[
+			'theme'    => 'flow',
 			'template' => 'layout/base.tpl',
 			'block'    => 'head_meta_robots',
 			'file'     => '/Application/views/blocks/head_meta_robots.tpl'
 		],
 		[
+			'theme'    => 'flow',
+			'template' => 'email/html/header.tpl',
+			'block'    => 'email_html_header',
+			'file'     => '/Application/views/blocks/email_html_header.tpl'
+		],
+		[
+			'theme'    => 'wave',
+			'template' => 'layout/base.tpl',
+			'block'    => 'base_js',
+			'file'     => '/Application/views/blocks/base_js.tpl'
+		],
+		[
+			'theme'    => 'wave',
+			'template' => 'layout/base.tpl',
+			'block'    => 'head_meta_robots',
+			'file'     => '/Application/views/blocks/head_meta_robots.tpl'
+		],
+		[
+			'theme'    => 'wave',
 			'template' => 'email/html/header.tpl',
 			'block'    => 'email_html_header',
 			'file'     => '/Application/views/blocks/email_html_header.tpl'


### PR DESCRIPTION
Hi Marat,

i use your module in a OXID6.2.2. I´ve the behavoir that your blocks not extend my theme. I checked that and found that other modules extend these blocks as well. The difference is that the blocks specifically address the "wave" theme. Since the definition is missing in your block, it is strangely ignored. Your block will only be shown to me when I add the theme definitions by hand. Since the theme option has basically no further effects, it would be nice if you added this to your module.
Thank you & Regards, Mario