### PR TITLE
Remove OXID class from metadata.php

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -48,8 +48,6 @@
  */
 $sMetadataVersion = '2.0';
 
-$oLang = \OxidEsales\Eshop\Core\Registry::getLang();
-
 $aModule = [
 	'id'          => 'matomo',
 	'title'       => '<strong style="color:#95b900;font-size:125%;">best</strong><strong style="color:#c4ca77;font-size:125%;">life</strong> <strong>Matomo Tracking (ehemals Piwik)</strong>',


### PR DESCRIPTION
This removes the use of the OXID Registry since it is not actually used and problematic for some OXID 6.2 setups if OXID classes are not available during installation.

- metadata.php should not contain additional source code since 6.2:
  https://docs.oxid-esales.com/eshop/en/6.2/releases/releases-2020/oxid-eshop-620.html#changes-in-the-module-system
- New Metadata version 2.1: "No other variables or code are allowed."
  https://docs.oxid-esales.com/developer/en/6.2/development/modules_components_themes/module/skeleton/metadataphp/version21.html